### PR TITLE
Assert modifier

### DIFF
--- a/html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html
+++ b/html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML>
+<title>clicks on label element with modifier keys </title>
+<link rel="author" title="Mu-An Chiou" href="mailto:hi@muan.co">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#the-label-element:the-label-element-10">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="log"></div>
+<div style="user-select: none;">
+  <label id="click-label" for="click">foo</label><input id="click" type="checkbox" />
+  <label id="shift-label" for="shift">foo</label><input id="shift" type="checkbox" />
+  <label id="alt-label" for="alt">foo</label><input id="alt" type="checkbox" />
+  <label id="meta-label" for="meta">foo</label><input id="meta" type="checkbox" />
+</div>
+<script>
+  "use strict";
+
+  function clickWithModifier(label, key) {
+    new test_driver.Actions()
+      .keyDown(key)
+      .pointerMove(0, 0, { origin: label })
+      .pointerDown()
+      .pointerUp()
+      .addTick()
+      .keyUp(key)
+      .send()
+  }
+
+  async_test(t => {
+    const label = document.getElementById("shift-label");
+    const input = document.getElementById("shift");
+
+    label.addEventListener("click", t.step_func(function (event) {
+      assert_true(event.shiftKey, 'shiftKey should be pressed on click');
+      t.done()
+    }));
+    clickWithModifier(label, "\uE008"); // ShiftLeft
+
+  }, "label with for attribute should proxy click events to the associated element on shift click");
+
+  async_test(t => {
+    const label = document.getElementById("alt-label");
+    const input = document.getElementById("alt");
+
+    label.addEventListener("click", t.step_func(function (event) {
+      assert_true(event.altKey, 'altKey should be pressed on click');
+      t.done()
+    }));
+    clickWithModifier(label, "\uE00A"); // AltLeft
+
+  }, "label with for attribute should proxy click events to the associated element on alt click");
+
+  async_test(t => {
+    const label = document.getElementById("meta-label");
+    const input = document.getElementById("meta");
+
+    label.addEventListener("click", t.step_func(function (event) {
+      assert_true(event.metaKey, 'metaKey should be pressed on click');
+      t.done()
+    }));
+    clickWithModifier(label, "\uE03D"); // OSLeft
+
+  }, "label with for attribute should proxy click events to the associated element on meta click");
+
+</script>

--- a/resources/testdriver-actions.js
+++ b/resources/testdriver-actions.js
@@ -324,7 +324,7 @@
         if (this.actions.has(i)) {
           actions.push(this.actions.get(i));
         } else {
-          actions.push({"type": "pause"});
+          actions.push({"type": "pause", duration: 0});
         }
       }
       return data;
@@ -375,7 +375,7 @@
         if (this.actions.has(i)) {
           actions.push(this.actions.get(i));
         } else {
-          actions.push({"type": "pause"});
+          actions.push({"type": "pause", duration: 0});
         }
       }
       return data;


### PR DESCRIPTION
Command:

```
./wpt run safari html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html --headless
```

Results:

```
Running 1 tests in web-platform-tests

  ▶ Unexpected subtest result in /html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html:
  │ FAIL [expected PASS] label with for attribute should proxy click events to the associated element on shift click
  │   → assert_true: shiftKey should be pressed on click expected true got false
  │ 
  │ http://web-platform.test:8000/html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html:36:18
  │ http://web-platform.test:8000/resources/testharness.js:1977:30
  └ http://web-platform.test:8000/resources/testharness.js:2002:40

  ▶ Unexpected subtest result in /html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html:
  │ FAIL [expected PASS] label with for attribute should proxy click events to the associated element on alt click
  │   → assert_true: altKey should be pressed on click expected true got false
  │ 
  │ http://web-platform.test:8000/html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html:48:18
  │ http://web-platform.test:8000/resources/testharness.js:1977:30
  └ http://web-platform.test:8000/resources/testharness.js:2002:40

  ▶ Unexpected subtest result in /html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html:
  │ FAIL [expected PASS] label with for attribute should proxy click events to the associated element on meta click
  │   → assert_true: metaKey should be pressed on click expected true got false
  │ 
  │ http://web-platform.test:8000/html/semantics/forms/the-label-element/assert-clicking-with-modifiers.html:60:18
  │ http://web-platform.test:8000/resources/testharness.js:1977:30
  └ http://web-platform.test:8000/resources/testharness.js:2002:40

Ran 1 tests finished in 7.8 seconds.
  • 0 ran as expected. 0 tests skipped.
  • 1 tests had unexpected subtest results
```

---

Firefox results:

```
Running 1 tests in web-platform-tests

Ran 1 tests finished in 5.1 seconds.
  • 1 ran as expected. 0 tests skipped.
```